### PR TITLE
Specifying source parameter on plugin

### DIFF
--- a/src/main/java/io/github/percontmx/plugins/xjc/XjcPlugin.java
+++ b/src/main/java/io/github/percontmx/plugins/xjc/XjcPlugin.java
@@ -12,12 +12,16 @@ public class XjcPlugin implements Plugin<Project> {
     public void apply(Project target) {
         target.getPluginManager().apply("java");
 
+        // Create XJC pluign configuration.
         target.getConfigurations().create("xjc", conf -> {
             conf.setVisible(false);
             conf.setTransitive(true);
             conf.setDescription("XJC configuration");
         });
 
+        // Adding JAXB-XJC dependency.
+        target.getDependencies().add("xjc",
+                "com.sun.xml.bind:jaxb-impl:4.0.5");
         target.getDependencies().add("xjc",
                 "com.sun.xml.bind:jaxb-xjc:4.0.5");
 
@@ -25,6 +29,8 @@ public class XjcPlugin implements Plugin<Project> {
                 DefaultXjcPluginExtension.class);
 
         target.getTasks().register("xjc", XjcTask.class, task -> {
+            XjcPluginExtension pluginExtension = target.getExtensions().getByType(XjcPluginExtension.class);
+            task.setSource(pluginExtension.getSource());
             task.setGroup("build");
             task.setDescription("Generates Java classes from XML schema");
             task.setClasspath(target.getConfigurations().getByName("xjc"));

--- a/src/main/java/io/github/percontmx/plugins/xjc/impl/XjcTask.java
+++ b/src/main/java/io/github/percontmx/plugins/xjc/impl/XjcTask.java
@@ -1,7 +1,33 @@
 package io.github.percontmx.plugins.xjc.impl;
 
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.Optional;
 
-public class XjcTask extends JavaExec {
+import java.util.ArrayList;
+import java.util.List;
 
+public abstract class XjcTask extends JavaExec {
+
+    private String source;
+
+    @Input
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    @Override
+    public void exec() {
+        List<String> args = new ArrayList<>();
+
+        args.add(source);
+
+        setArgs(args);
+
+        super.exec();
+    }
 }

--- a/src/main/java/io/github/percontmx/plugins/xjc/impl/XjcTask.java
+++ b/src/main/java/io/github/percontmx/plugins/xjc/impl/XjcTask.java
@@ -2,7 +2,6 @@ package io.github.percontmx.plugins.xjc.impl;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.JavaExec;
-import org.gradle.api.tasks.Optional;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/io/github/percontmx/plugins/xjc/XjcTaskTest.java
+++ b/src/test/java/io/github/percontmx/plugins/xjc/XjcTaskTest.java
@@ -1,0 +1,109 @@
+package io.github.percontmx.plugins.xjc;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Objects;
+
+public class XjcTaskTest {
+
+    @Rule
+    public TemporaryFolder projectDir = new TemporaryFolder();
+
+    private final static String BUILD_FILE_CONTENTS = """
+                plugins {
+                    id 'io.github.percontmx.xjc-plugin'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                """;
+
+    @Test
+    public void shouldGenerateCodeWhenSourceSchemaIsSpecified() throws IOException {
+        String sampleSchemaPath = Objects.requireNonNull(getClass().getResource("schema_01.xsd")).getPath();
+        String testBuildFileWithSource = BUILD_FILE_CONTENTS.concat("""                
+                xjc {
+                    source = 'sampleSchemaPath'
+                }
+                """).replace("sampleSchemaPath", sampleSchemaPath);
+        File file = projectDir.newFile("build.gradle");
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(testBuildFileWithSource);
+        }
+
+        BuildResult build = GradleRunner.create()
+                .withProjectDir(projectDir.getRoot()).withArguments("xjc")
+                .withPluginClasspath()
+                .build();
+        System.out.println(build.getOutput());
+        Assert.assertTrue(build.getOutput().contains("BUILD SUCCESSFUL"));
+    }
+
+    @Test
+    public void shouldGenerateCodeWhenSourceDirectoryIsSpecified() throws IOException {
+        String sampleSchemaPath = Objects.requireNonNull(getClass().getResource("schema_01.xsd")).getPath();
+        File f = new File(sampleSchemaPath);
+        String sampleSchemaDir = f.getParent();
+        String testBuildFileWithSource = BUILD_FILE_CONTENTS.concat("""                
+                xjc {
+                    source = 'sampleSchemaDir'
+                }
+                """).replace("sampleSchemaDir", sampleSchemaDir);
+        File file = projectDir.newFile("build.gradle");
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(testBuildFileWithSource);
+        }
+
+        BuildResult build = GradleRunner.create()
+                .withProjectDir(projectDir.getRoot()).withArguments("xjc")
+                .withPluginClasspath()
+                .build();
+        System.out.println(build.getOutput());
+        Assert.assertTrue(build.getOutput().contains("BUILD SUCCESSFUL"));
+    }
+
+    @Test
+    public void shouldGenerateCodeWhenSourceUrlIsSpecified() throws IOException {
+        String sampleSchemaUrl = "http://www.sat.gob.mx/sitio_internet/cfd/tipoDatos/tdCFDI/tdCFDI.xsd";
+        String testBuildFileWithSource = BUILD_FILE_CONTENTS.concat("""                
+                xjc {
+                    source = 'sampleSchemaUrl'
+                }
+                """).replace("sampleSchemaUrl", sampleSchemaUrl);
+        File file = projectDir.newFile("build.gradle");
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(testBuildFileWithSource);
+        }
+
+        BuildResult build = GradleRunner.create()
+                .withProjectDir(projectDir.getRoot()).withArguments("xjc")
+                .withPluginClasspath()
+                .build();
+        System.out.println(build.getOutput());
+        Assert.assertTrue(build.getOutput().contains("BUILD SUCCESSFUL"));
+    }
+
+    @Test
+    public void shouldFailWhenSourceIsNotSpecified() throws IOException {
+        File file = projectDir.newFile("build.gradle");
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(BUILD_FILE_CONTENTS);
+        }
+
+        BuildResult build = GradleRunner.create()
+                .withProjectDir(projectDir.getRoot()).withArguments("xjc")
+                .withPluginClasspath()
+                .buildAndFail();
+        System.out.println(build.getOutput());
+        Assert.assertTrue(build.getOutput().contains("property 'source' doesn't have a configured value"));
+    }
+}

--- a/src/test/java/io/github/percontmx/plugins/xjc/XjcTaskTest.java
+++ b/src/test/java/io/github/percontmx/plugins/xjc/XjcTaskTest.java
@@ -3,6 +3,7 @@ package io.github.percontmx.plugins.xjc;
 import io.github.percontmx.plugins.xjc.impl.XjcTask;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +42,12 @@ public class XjcTaskTest {
        xjc.setSource(schemaPath);
        xjc.exec();
 
+       File projectRoot = projectDir.getRoot();
+       Assert.assertNotNull(projectRoot);
+
+       File[] files = projectRoot.listFiles();
+       Assert.assertNotNull(files);
+       Assert.assertTrue(files.length > 0);
     }
 
     @Test
@@ -52,6 +59,13 @@ public class XjcTaskTest {
         XjcTask xjc = (XjcTask) testProject.getTasks().getByName("xjc");
         xjc.setSource(sampleSchemaDir);
         xjc.exec();
+
+        File projectRoot = projectDir.getRoot();
+        Assert.assertNotNull(projectRoot);
+
+        File[] files = projectRoot.listFiles();
+        Assert.assertNotNull(files);
+        Assert.assertTrue(files.length > 0);
     }
 
     @Test
@@ -60,6 +74,13 @@ public class XjcTaskTest {
         XjcTask xjc = (XjcTask) testProject.getTasks().getByName("xjc");
         xjc.setSource(url);
         xjc.exec();
+
+        File projectRoot = projectDir.getRoot();
+        Assert.assertNotNull(projectRoot);
+
+        File[] files = projectRoot.listFiles();
+        Assert.assertNotNull(files);
+        Assert.assertTrue(files.length > 0);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/resources/io/github/percontmx/plugins/xjc/schema_01.xsd
+++ b/src/test/resources/io/github/percontmx/plugins/xjc/schema_01.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://www.percont.com.mx/plugins/xjc/test"
+        xmlns:tst="http://www.percont.com.mx/plugins/xjc/test">
+
+    <complexType name="person">
+        <attribute name="name" type="string" use="required" />
+        <attribute name="dob" type="date" use="required" />
+    </complexType>
+
+    <element name="people">
+        <complexType>
+            <sequence>
+                <element name="person" type="tst:person" maxOccurs="unbounded" />
+            </sequence>
+        </complexType>
+    </element>
+
+</schema>


### PR DESCRIPTION
This change allows the user to specify the source to take xsd's from.

As per XJC specification, the following formats are supported:

- Path to specific schema file.
- Path to directory containing schemas.
- Schema file URL.

